### PR TITLE
A number of changes that make the project build and run using Mono on Mac

### DIFF
--- a/Logger/FileLog.cs
+++ b/Logger/FileLog.cs
@@ -11,7 +11,7 @@
     {
         private static Object lockObject = new object();
 
-        internal static readonly string LogDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\TraktRater\Logs";
+        internal static readonly string LogDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"TraktRater", @"Logs");
         internal static string LogFileName { private get; set; }
 
         static FileLog()
@@ -102,7 +102,7 @@
 
         private static void WriteToFile(String log)
         {
-            string filename = LogDirectory + "\\" + LogFileName;
+            string filename = Path.Combine(LogDirectory, LogFileName);
 
             try
             {

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -114,7 +114,7 @@
         {
             get
             {
-                return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\TraktRater\Settings.xml";
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"TraktRater", @"Settings.xml");
             }
         }
 
@@ -142,34 +142,39 @@
         /// </summary>
         public static void Load()
         {
-            XmlReader xmlReader = new XmlReader();
-            xmlReader.Load(SettingsFile);
+            try {
+                XmlReader xmlReader = new XmlReader();
+                xmlReader.Load(SettingsFile);
 
-            TraktUsername = xmlReader.GetSettingValueAsString(cTraktUsername, string.Empty);
-            TraktPassword = xmlReader.GetSettingValueAsString(cTraktPassword, string.Empty);
-            TVDbAccountIdentifier = xmlReader.GetSettingValueAsString(cTVDbAccountId, string.Empty);
-            TMDbSessionId = xmlReader.GetSettingValueAsString(cTMDbSessionId, string.Empty);
-            TMDbSyncWatchlist = xmlReader.GetSettingValueAsBool(cTMDBSyncWatchlist, true);
-            IMDbRatingsFilename = xmlReader.GetSettingValueAsString(cIMDbRatingsFilename, string.Empty);
-            IMDbWatchlistFilename = xmlReader.GetSettingValueAsString(cIMDbWatchlistFilename, string.Empty);
-            IMDbUsername = xmlReader.GetSettingValueAsString(cIMDbUsername, string.Empty);
-            IMDbSyncWatchlist = xmlReader.GetSettingValueAsBool(cIMDBSyncWatchlist, false);
-            ListalSyncWatchlist = xmlReader.GetSettingValueAsBool(cListalSyncWatchlist, false);
-            ListalMovieFilename = xmlReader.GetSettingValueAsString(cListalMovieFilename, string.Empty);
-            ListalShowFilename = xmlReader.GetSettingValueAsString(cListalShowFilename, string.Empty);
-            CritickerMovieFilename = xmlReader.GetSettingValueAsString(cCritickerMovieFilename, string.Empty);
-            MarkAsWatched = xmlReader.GetSettingValueAsBool(cMarkAsWatched, true);
-            IgnoreWatchedForWatchlist = xmlReader.GetSettingValueAsBool(cIgnoreWatchedForWatchlist, true);
-            EnableIMDb = xmlReader.GetSettingValueAsBool(cEnableIMDb, false);
-            EnableTMDb = xmlReader.GetSettingValueAsBool(cEnableTMDb, false);
-            EnableTVDb = xmlReader.GetSettingValueAsBool(cEnableTVDb, false);
-            EnableListal = xmlReader.GetSettingValueAsBool(cEnableListal, false);
-            EnableCriticker = xmlReader.GetSettingValueAsBool(cEnableCriticker, false);
-            LogSeverityLevel = (LoggingSeverity)(xmlReader.GetSettingValueAsInt(cLogLevel, 3));
-            BatchSize = xmlReader.GetSettingValueAsInt(cBatchSize, 50);
+                TraktUsername = xmlReader.GetSettingValueAsString(cTraktUsername, string.Empty);
+                TraktPassword = xmlReader.GetSettingValueAsString(cTraktPassword, string.Empty);
+                TVDbAccountIdentifier = xmlReader.GetSettingValueAsString(cTVDbAccountId, string.Empty);
+                TMDbSessionId = xmlReader.GetSettingValueAsString(cTMDbSessionId, string.Empty);
+                TMDbSyncWatchlist = xmlReader.GetSettingValueAsBool(cTMDBSyncWatchlist, true);
+                IMDbRatingsFilename = xmlReader.GetSettingValueAsString(cIMDbRatingsFilename, string.Empty);
+                IMDbWatchlistFilename = xmlReader.GetSettingValueAsString(cIMDbWatchlistFilename, string.Empty);
+                IMDbUsername = xmlReader.GetSettingValueAsString(cIMDbUsername, string.Empty);
+                IMDbSyncWatchlist = xmlReader.GetSettingValueAsBool(cIMDBSyncWatchlist, false);
+                ListalSyncWatchlist = xmlReader.GetSettingValueAsBool(cListalSyncWatchlist, false);
+                ListalMovieFilename = xmlReader.GetSettingValueAsString(cListalMovieFilename, string.Empty);
+                ListalShowFilename = xmlReader.GetSettingValueAsString(cListalShowFilename, string.Empty);
+                CritickerMovieFilename = xmlReader.GetSettingValueAsString(cCritickerMovieFilename, string.Empty);
+                MarkAsWatched = xmlReader.GetSettingValueAsBool(cMarkAsWatched, true);
+                IgnoreWatchedForWatchlist = xmlReader.GetSettingValueAsBool(cIgnoreWatchedForWatchlist, true);
+                EnableIMDb = xmlReader.GetSettingValueAsBool(cEnableIMDb, false);
+                EnableTMDb = xmlReader.GetSettingValueAsBool(cEnableTMDb, false);
+                EnableTVDb = xmlReader.GetSettingValueAsBool(cEnableTVDb, false);
+                EnableListal = xmlReader.GetSettingValueAsBool(cEnableListal, false);
+                EnableCriticker = xmlReader.GetSettingValueAsBool(cEnableCriticker, false);
+                LogSeverityLevel = (LoggingSeverity)(xmlReader.GetSettingValueAsInt(cLogLevel, 3));
+                BatchSize = xmlReader.GetSettingValueAsInt(cBatchSize, 50);
 
-            // save settings, might be some new settings added
-            Save();
+                // save settings, might be some new settings added
+                Save();
+            }
+            catch (Exception) {
+                return;
+            }
         }
 
         /// <summary>

--- a/Settings/XMLWriter.cs
+++ b/Settings/XMLWriter.cs
@@ -38,7 +38,7 @@
             {
                 document.Load(file);
             }
-            catch (XmlException)
+            catch (Exception)
             {
                 document = null;
                 return false;

--- a/Sites/API/TVDb/TVDbCache.cs
+++ b/Sites/API/TVDb/TVDbCache.cs
@@ -7,10 +7,10 @@
     {
         static readonly string cAppDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
-        public static readonly string cEpisodeRatingsFileCache = cAppDir + @"\TraktRater\Ratings\{0}.xml";
-        public static readonly string cShowRatingsFileCache = cAppDir + @"\TraktRater\Ratings\series.xml";
-        public static readonly string cShowInfoFileCache = cAppDir + @"\TraktRater\Series\{0}.xml";
-        public static readonly string cShowSearchFileCache = cAppDir + @"\TraktRater\SearchResults\tvdb_{0}.xml";
+        public static readonly string cEpisodeRatingsFileCache = Path.Combine(cAppDir, @"TraktRater", @"Ratings", @"{0}.xml");
+        public static readonly string cShowRatingsFileCache = Path.Combine(cAppDir, @"TraktRater", @"Ratings", @"series.xml");
+        public static readonly string cShowInfoFileCache = Path.Combine(cAppDir, @"TraktRater", @"Series", @"{0}.xml");
+        public static readonly string cShowSearchFileCache = Path.Combine(cAppDir, @"TraktRater", @"SearchResults", @"tvdb_{0}.xml");
 
         public static string GetFromCache(string filename, int expiresInDays = 1)
         {

--- a/Sites/IMDb.cs
+++ b/Sites/IMDb.cs
@@ -83,9 +83,9 @@ namespace TraktRater.Sites
 
             #region Import Rated Movies
             var movies = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie && !string.IsNullOrEmpty(r[IMDbFieldMapping.cRating])).ToList();
+            FileLog.Info("Found {0} movie ratings in CSV file", movies.Count);
             if (movies.Any())
             {
-                FileLog.Info("Found {0} movie ratings in CSV file", movies.Count);
                 UIUtils.UpdateStatus("Retrieving existing movie ratings from trakt.tv");
                 var currentUserMovieRatings = TraktAPI.TraktAPI.GetRatedMovies();
 
@@ -127,9 +127,9 @@ namespace TraktRater.Sites
 
             #region Import Rated TV Shows
             var shows = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Show && !string.IsNullOrEmpty(r[IMDbFieldMapping.cRating])).ToList();
+            FileLog.Info("Found {0} tv show ratings in CSV file", shows.Count);
             if (shows.Any())
             {
-                FileLog.Info("Found {0} tv show ratings in CSV file", shows.Count);
                 UIUtils.UpdateStatus("Retrieving existing tv show ratings from trakt.tv");
                 var currentUserShowRatings = TraktAPI.TraktAPI.GetRatedShows();
 
@@ -172,9 +172,9 @@ namespace TraktRater.Sites
             #region Import Rated Episodes
             var imdbEpisodes = new List<IMDbEpisode>();
             var imdbCSVEpisodes = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Episode).ToList();
+            FileLog.Info("Found {0} tv episode ratings in CSV file", imdbCSVEpisodes.Count);
             if (imdbCSVEpisodes.Any())
             {
-                FileLog.Info("Found {0} tv episode ratings in CSV file", imdbCSVEpisodes.Count);
 
                 // we can't rely on the imdb id as trakt most likely wont have the info for episodes
 
@@ -313,9 +313,9 @@ namespace TraktRater.Sites
 
             #region Import Watchlist Movies
             movies = watchlistItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie).ToList();
+            FileLog.Info("Found {0} movies watchlisted in CSV file", movies.Count);
             if (movies.Any())
             {
-                FileLog.Info("Found {0} movies watchlisted in CSV file", movies.Count);
                 UIUtils.UpdateStatus("Requesting existing watchlist movies from trakt...");
                 var watchlistTraktMovies = TraktAPI.TraktAPI.GetWatchlistMovies();
                 if (watchlistTraktMovies != null)
@@ -380,9 +380,9 @@ namespace TraktRater.Sites
             #region Import Watchlist TV Shows
             IEnumerable<TraktShowPlays> watchedTraktShows = null;
             shows = watchlistItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Show).ToList();
+            FileLog.Info("Found {0} tv shows watchlisted in CSV file", shows.Count);
             if (shows.Any())
             {
-                FileLog.Info("Found {0} tv shows watchlisted in CSV file", shows.Count);
                 UIUtils.UpdateStatus("Requesting existing watchlist shows from trakt...");
                 var watchlistTraktShows = TraktAPI.TraktAPI.GetWatchlistShows();
                 if (watchlistTraktShows != null)
@@ -438,9 +438,9 @@ namespace TraktRater.Sites
             #region Import Watchlist Episodes
             imdbEpisodes.Clear();
             imdbCSVEpisodes = watchlistItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Episode).ToList();
+            FileLog.Info("Found {0} tv episodes watchlisted in CSV file", imdbCSVEpisodes.Count);
             if (imdbCSVEpisodes.Any())
             {
-                FileLog.Info("Found {0} tv episodes watchlisted in CSV file", imdbCSVEpisodes.Count);
                 UIUtils.UpdateStatus("Found {0} IMDb watchlist episodes", imdbCSVEpisodes.Count());
 
                 imdbEpisodes.AddRange(imdbCSVEpisodes.Select(Helper.GetIMDbEpisodeFromTVDb).Where(imdbEpisode => imdbEpisode != null));

--- a/Sites/IMDb.cs
+++ b/Sites/IMDb.cs
@@ -520,6 +520,7 @@ namespace TraktRater.Sites
             if (!File.Exists(filename)) return false;
 
             string[] fieldHeadings = new string[]{};
+            int recordNumber = 0;
             
             try
             {
@@ -527,12 +528,13 @@ namespace TraktRater.Sites
                 parser.SetDelimiters(",");
                 while (!parser.EndOfData)
                 {
+                    recordNumber++;
                     // processing fields in row
                     string[] fields = parser.ReadFields();
 
                     // get header fields
                     // line number increments after first read
-                    if (parser.LineNumber == 2)
+                    if (recordNumber == 1)
                     {
                         fieldHeadings = fields;
                         continue;

--- a/Sites/IMDb.cs
+++ b/Sites/IMDb.cs
@@ -234,7 +234,8 @@ namespace TraktRater.Sites
             {
                 #region Movies
                 // compare all movies rated against what's not watched on trakt
-                movies = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie && !string.IsNullOrEmpty(r[IMDbFieldMapping.cRating])).ToList();
+                movies = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie).ToList();
+                FileLog.Info("Found {0} movies in CSV file", movies.Count);
                 if (movies.Count > 0)
                 {
                     // get watched movies from trakt.tv

--- a/TraktAPI/TraktCache.cs
+++ b/TraktAPI/TraktCache.cs
@@ -7,7 +7,7 @@
     {
         static string cAppDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         
-        public static string cShowInfoFileCache = cAppDir + @"\TraktRater\Series\{0}.json";
+        public static string cShowInfoFileCache = Path.Combine(cAppDir, @"TraktRater", @"Series", @"{0}.json");
 
         public static string GetFromCache(string filename, int expiresInDays)
         {

--- a/TraktRater.cs
+++ b/TraktRater.cs
@@ -39,6 +39,7 @@
         #region Constructor
         public TraktRater()
         {
+			FileLog.LogFileName = DateTime.Now.ToString("yyyyMMdd_hhmmss") + ".log";
             InitializeComponent();
         }
         #endregion


### PR DESCRIPTION
A number of changes that make the project build and run using Mono on Mac.

The changes to TVDbCache.cs (because I do not have an account) and TraktCache.cs (because it seems unused) have not yet been tested.
To maintain compatibility when making changes it is important to use Path.Combine() to compose a file path instead of manually using the '\' path delimiter.