### PR TITLE
Mark movies as watched if they appear in the IMDb csv ratings file ev…

### DIFF
--- a/Sites/IMDb.cs
+++ b/Sites/IMDb.cs
@@ -234,7 +234,8 @@ namespace TraktRater.Sites
             {
                 #region Movies
                 // compare all movies rated against what's not watched on trakt
-                movies = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie && !string.IsNullOrEmpty(r[IMDbFieldMapping.cRating])).ToList();
+                movies = rateItems.Where(r => r[IMDbFieldMapping.cType].ItemType() == IMDbType.Movie).ToList();
+                FileLog.Info("Found {0} movies in CSV file", movies.Count);
                 if (movies.Count > 0)
                 {
                     // get watched movies from trakt.tv


### PR DESCRIPTION
…en if they do not have a rate assigned.

I made this change because I have an IMDb list with movies I have watched but not rated. It would be nice if this could be imported by TraktRater.

This works fine for IMDb but I have not looked at other services.
The GUI text has also not been modified to reflect this change in behaviour.